### PR TITLE
Remove the :gpb dependency in favour of :small_ints

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule MarcoPolo.Mixfile do
 
   defp deps do
     [{:connection, github: "fishcakez/connection"},
-     {:gpb, github: "tomas-abrahamsson/gpb", tag: "3.18.6"}]
+     {:small_ints, github: "whatyouhide/small_ints"}]
   end
 
   # This beauty is taken almost verbatim from the mix.exs file of the Ecto

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"connection": {:git, "git://github.com/fishcakez/connection.git", "0673602e65532f9e11e95cd9dd80968731183dd6", []},
-  "gpb": {:git, "git://github.com/tomas-abrahamsson/gpb.git", "17b8343093f22153c4473fad4df3e0934ef6d431", [tag: "3.18.6"]}}
+  "gpb": {:git, "git://github.com/tomas-abrahamsson/gpb.git", "17b8343093f22153c4473fad4df3e0934ef6d431", [tag: "3.18.6"]},
+  "small_ints": {:git, "git://github.com/whatyouhide/small_ints.git", "9c1174face8d1de579d65f543102d230b04c4d86", []}}


### PR DESCRIPTION
`:small_ints` is an Erlang library I wrote that just implements the ZigZag and varint encoding/decoding algorithms, which is exactly what we need in this project.

Let's hope it works out fine :)

https://github.com/whatyouhide/small_ints
