### PR TITLE
change INT to INTEGER in record serialization

### DIFF
--- a/lib/marco_polo/protocol/record_serialization.ex
+++ b/lib/marco_polo/protocol/record_serialization.ex
@@ -502,7 +502,7 @@ defmodule MarcoPolo.Protocol.RecordSerialization do
   # http://orientdb.com/docs/last/Types.html
   @types [
     {:boolean, "BOOLEAN", 0},
-    {:int, "INT", 1},
+    {:int, "INTEGER", 1},
     {:short, "SHORT", 2},
     {:long, "LONG", 3},
     {:float, "FLOAT", 4},


### PR DESCRIPTION
I created a integer property and I got this error:

```
iex(3)> MarcoPolo.command(conn, "Insert into MyClass(prop, prop2) VALUES ('prop5', 5), ('prop6', 6)")
** (EXIT from #PID<0.131.0>) an exception was raised:
    ** (FunctionClauseError) no function clause matching in MarcoPolo.Protocol.RecordSerialization.string_to_type/1
        (marco_polo) lib/marco_polo/protocol/record_serialization.ex:533: MarcoPolo.Protocol.RecordSerialization.string_to_type("INTEGER")
        (marco_polo) lib/marco_polo/protocol/record_serialization.ex:97: MarcoPolo.Protocol.RecordSerialization.decode_property_definition/3
        (marco_polo) lib/marco_polo/protocol/record_serialization.ex:80: MarcoPolo.Protocol.RecordSerialization.decode_header/3
        (marco_polo) lib/marco_polo/protocol/record_serialization.ex:56: MarcoPolo.Protocol.RecordSerialization.decode_embedded/2
        (marco_polo) lib/marco_polo/protocol/record_serialization.ex:26: MarcoPolo.Protocol.RecordSerialization.decode/2
        (marco_polo) lib/marco_polo/protocol.ex:392: MarcoPolo.Protocol.parse_record_with_rid/2
        (marco_polo) lib/marco_polo/generic_parser.ex:82: MarcoPolo.GenericParser.parse_array/4
        (marco_polo) lib/marco_polo/generic_parser.ex:50: MarcoPolo.GenericParser.parse/3
```

Just change it to match and it works.

I don't know if this would have side effects somewhere else though...
