### PR TITLE
Add connection to application list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule MarcoPolo.Mixfile do
   end
 
   def application do
-    [applications: [:logger] ++ if(Mix.env == :test, do: [:dotenv], else: []),
+    [applications: [:logger, :connection] ++ if(Mix.env == :test, do: [:dotenv], else: []),
      env: [client_name: @client_name, version: @version]]
   end
 


### PR DESCRIPTION
When running in a release built by exrm, you have to list any dependent applications or the application will fail to start. This took me a while to debug, but it's a simple fix and doesn't hurt anything :)