### PR TITLE
Fix a bunch of live-query-related things

### DIFF
--- a/lib/marco_polo/connection.ex
+++ b/lib/marco_polo/connection.ex
@@ -92,10 +92,6 @@ defmodule MarcoPolo.Connection do
     Connection.call(pid, {:live_query, args, receiver}, opts[:timeout] || @timeout)
   end
 
-  def live_query_unsubscribe(pid, token) do
-    Connection.cast(pid, {:live_query_unsubscribe, token})
-  end
-
   @doc """
   Fetch the schema and store it into the state.
 
@@ -217,11 +213,6 @@ defmodule MarcoPolo.Connection do
 
   def handle_cast(:stop, s) do
     {:disconnect, :stop, s}
-  end
-
-  def handle_cast({:live_query_unsubscribe, token}, s) do
-    s = update_in(s.live_query_tokens, &Dict.delete(&1, token))
-    {:noreply, s}
   end
 
   @doc false

--- a/lib/marco_polo/connection/live_query.ex
+++ b/lib/marco_polo/connection/live_query.ex
@@ -24,6 +24,9 @@ defmodule MarcoPolo.Connection.LiveQuery do
     case Protocol.parse_push_data(data, s.schema) do
       :incomplete ->
         %{s | tail: data}
+      {:ok, {token, :unsubscribed}, rest} ->
+        send_live_query_data_resp(s, token, :unsubscribed)
+        update_in(s.live_query_tokens, &Dict.delete(&1, token))
       {:ok, {token, resp}, rest} ->
         send_live_query_data_resp(s, token, resp)
         %{s | tail: rest}

--- a/test/marco_polo_misc_test.exs
+++ b/test/marco_polo_misc_test.exs
@@ -325,6 +325,7 @@ defmodule MarcoPoloMiscTest do
     assert doc.fields["text"] == "updated"
 
     assert :ok = live_query_unsubscribe(c, token)
+    assert_receive {:orientdb_live_query, ^token, :unsubscribed}
 
     {:ok, _} = command(c, "INSERT INTO LiveQuerying(text) VALUES ('unsubscribed')")
     refute_receive {:orientdb_live_query, _, _}


### PR DESCRIPTION
I assume OrientDB 2.2.0-beta changed the format of live queries, this PR should adapt to the new changes.