### PR TITLE
Fix to support when string default to nil

### DIFF
--- a/lib/marco_polo/protocol/record_serialization.ex
+++ b/lib/marco_polo/protocol/record_serialization.ex
@@ -570,11 +570,17 @@ defmodule MarcoPolo.Protocol.RecordSerialization do
   defp nullify_empty_string(str) when is_binary(str), do: str
 
   defp get_rest_from_list_of_fields([_|_] = fields) do
+    case get_serialized_data(fields) do
+      nil -> <<>>
+      {{_name, _value}, serialized_data} -> serialized_data
+    end
+  end
+
+  defp get_serialized_data(fields) do
     fields
     |> Enum.reverse()
     |> Enum.drop_while(fn {{_name, val}, _rest} -> is_nil(val) end)
     |> List.first()
-    |> elem(1)
   end
 
   defp fields_to_map(fields) do


### PR DESCRIPTION
With the new version of OrientDB we have a different behaviour when returning empty value for a string. With the latest version the the values are default to nil. For this reason when they are looping through `Enum.drop_while` all of them are excluded resulting an empty list.

Here is an example of the fields when empty.
```
[
  {{"address_line_1", nil}, ""},
  {{"address_line_2", nil}, ""},
  {{"country", nil}, ""},
  {{"county", nil}, ""},
  {{"full_address", nil}, ""},
  {{"postcode", nil}, ""},
  {{"town", nil}, ""}
]
```

This fix will aim to handle this case introduced with the latest version of OrientDB 

Problem found in OrientDB v2.2.3 enterprise edition
Previous version working OrientDB v2.1.7 enterprise edition